### PR TITLE
Bower should ignore 'tests' directory.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
 	},
 	"ignore": [
 		".*",
-		"test"
+		"tests"
 	],
 	"license": [ "BSD-3-Clause" ],
 	"moduleType": [ "amd" ]


### PR DESCRIPTION
`bower.json` ignores a `test` directory when it should ignore the `tests` directory. The [original issue](https://github.com/dojo/dojo2-package-template/issues/5) was opened under the [Dojo 2 package template repo](https://github.com/dojo/dojo2-package-template/).
