### PR TITLE
Update Dojo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "dojo-crypto",
 	"version": "2.0.0-pre",
 	"description": "Cryptographic utilities",
-	"homepage": "http://dojotoolkit.org",
+	"homepage": "https://dojo.io",
 	"bugs": {
 		"url": "https://github.com/dojo/crypto/issues"
 	},


### PR DESCRIPTION
Updated the homepage URL in package.json to point to https://dojo.io.

Refs: dojo/meta#166